### PR TITLE
Fix: Missing member photos not displaying

### DIFF
--- a/Team Page/team-2k20.html
+++ b/Team Page/team-2k20.html
@@ -537,7 +537,7 @@
 
                             <div class="cardz">
                               <div class="img-bx">
-                                <img src="assets\team_images\Vyom Sharma.JPG" alt="img" />
+                                <img src="assets\team_images\vyom sharma.jpg" alt="img" />
                               </div>
                               <div class="content1">
                                 <div class="detail">
@@ -1377,7 +1377,7 @@
 
                                                           <div class="cardz">
                                                             <div class="img-bx">
-                                                              <img src="assets\team_images\VAISHNAVI SHARMA.jpg" alt="img" />
+                                                              <img src="assets\team_images\Vaishnavi Sharma.jpg" alt="img" />
                                                             </div>
                                                             <div class="content1">
                                                               <div class="detail">


### PR DESCRIPTION
Fixed missing member photos that were not showing on the deployed website. Adjusted file names/paths to resolve issue.